### PR TITLE
Changed '--np' to '-np' to avoid error when using Intel mpiexec.

### DIFF
--- a/nightly/actuatorLine/actuatorLine.sh
+++ b/nightly/actuatorLine/actuatorLine.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i actuatorLine.i -o actuatorLine.log
+    mpiexec -np 8 ../../naluX -i actuatorLine.i -o actuatorLine.log
     determine_pass_fail $testTol "actuatorLine.log" "actuatorLine.norm" "actuatorLine.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/concentricRad/concentricRad.sh
+++ b/nightly/concentricRad/concentricRad.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i concentricRad.i -o concentricRad.log
+    mpiexec -np 4 ../../naluX -i concentricRad.i -o concentricRad.log
     determine_pass_fail $testTol "concentricRad.log" "concentricRad.norm" "concentricRad.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformal/dgNonConformal.sh
+++ b/nightly/dgNonConformal/dgNonConformal.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformal.i -o dgNonConformal.log
+    mpiexec -np 4 ../../naluX -i dgNonConformal.i -o dgNonConformal.log
     determine_pass_fail $testTol "dgNonConformal.log" "dgNonConformal.norm" "dgNonConformal.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformal3dFluids/dgNonConformal3dFluids.sh
+++ b/nightly/dgNonConformal3dFluids/dgNonConformal3dFluids.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformal3dFluids.i -o dgNonConformal3dFluids.log
+    mpiexec -np 4 ../../naluX -i dgNonConformal3dFluids.i -o dgNonConformal3dFluids.log
     determine_pass_fail $testTol "dgNonConformal3dFluids.log" "dgNonConformal3dFluids.norm" "dgNonConformal3dFluids.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformal3dFluidsHexTet/dgNonConformal3dFluidsHexTet.sh
+++ b/nightly/dgNonConformal3dFluidsHexTet/dgNonConformal3dFluidsHexTet.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformal3dFluidsHexTet.i -o dgNonConformal3dFluidsHexTet.log
+    mpiexec -np 4 ../../naluX -i dgNonConformal3dFluidsHexTet.i -o dgNonConformal3dFluidsHexTet.log
     determine_pass_fail $testTol "dgNonConformal3dFluidsHexTet.log" "dgNonConformal3dFluidsHexTet.norm" "dgNonConformal3dFluidsHexTet.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformalEdge/dgNonConformalEdge.sh
+++ b/nightly/dgNonConformalEdge/dgNonConformalEdge.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformalEdge.i -o dgNonConformalEdge.log
+    mpiexec -np 4 ../../naluX -i dgNonConformalEdge.i -o dgNonConformalEdge.log
     determine_pass_fail $testTol "dgNonConformalEdge.log" "dgNonConformalEdge.norm" "dgNonConformalEdge.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformalEdgeCylinder/dgNonConformalEdgeCylinder.sh
+++ b/nightly/dgNonConformalEdgeCylinder/dgNonConformalEdgeCylinder.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i dgNonConformalEdgeCylinder.i -o dgNonConformalEdgeCylinder.log
+    mpiexec -np 8 ../../naluX -i dgNonConformalEdgeCylinder.i -o dgNonConformalEdgeCylinder.log
     determine_pass_fail $testTol "dgNonConformalEdgeCylinder.log" "dgNonConformalEdgeCylinder.norm" "dgNonConformalEdgeCylinder.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformalFluids/dgNonConformalFluids.sh
+++ b/nightly/dgNonConformalFluids/dgNonConformalFluids.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformalFluids.i -o dgNonConformalFluids.log
+    mpiexec -np 4 ../../naluX -i dgNonConformalFluids.i -o dgNonConformalFluids.log
     determine_pass_fail $testTol "dgNonConformalFluids.log" "dgNonConformalFluids.norm" "dgNonConformalFluids.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformalFluidsEdge/dgNonConformalFluidsEdge.sh
+++ b/nightly/dgNonConformalFluidsEdge/dgNonConformalFluidsEdge.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformalFluidsEdge.i -o dgNonConformalFluidsEdge.log
+    mpiexec -np 4 ../../naluX -i dgNonConformalFluidsEdge.i -o dgNonConformalFluidsEdge.log
     determine_pass_fail $testTol "dgNonConformalFluidsEdge.log" "dgNonConformalFluidsEdge.norm" "dgNonConformalFluidsEdge.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/dgNonConformalThreeBlade/dgNonConformalThreeBlade.sh
+++ b/nightly/dgNonConformalThreeBlade/dgNonConformalThreeBlade.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i dgNonConformalThreeBlade.i -o dgNonConformalThreeBlade.log
+    mpiexec -np 4 ../../naluX -i dgNonConformalThreeBlade.i -o dgNonConformalThreeBlade.log
     determine_pass_fail $testTol "dgNonConformalThreeBlade.log" "dgNonConformalThreeBlade.norm" "dgNonConformalThreeBlade.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/ductWedge/ductWedge.sh
+++ b/nightly/ductWedge/ductWedge.sh
@@ -23,7 +23,7 @@ if [ -f $CWD/PASS ]; then
     didSimulationDiffAnywhere=0
 else
     # run the first case
-    mpiexec --np 2 ../../naluX -i ductWedge.i -o ductWedge.log
+    mpiexec -np 2 ../../naluX -i ductWedge.i -o ductWedge.log
     determine_pass_fail $testTol "ductWedge.log" "ductWedge.norm" "ductWedge.norm.gold"
     didSimulationDiffAnywhereFirst="$?"
     localDiffOne=$GlobalMaxSolutionDiff
@@ -32,7 +32,7 @@ else
     fi
 
     # run the second case
-    mpiexec --np 2 ../../naluX -i ductWedge_Input.i -o ductWedge_Input.log
+    mpiexec -np 2 ../../naluX -i ductWedge_Input.i -o ductWedge_Input.log
     determine_pass_fail $testTol "ductWedge_Input.log" "ductWedge_Input.norm" "ductWedge_Input.norm.gold"
     didSimulationDiffAnywhereSecond="$?"
     localDiffTwo=$GlobalMaxSolutionDiff

--- a/nightly/edgeContact3D/edgeContact3D.sh
+++ b/nightly/edgeContact3D/edgeContact3D.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i edgeContact3D.i -o edgeContact3D.log
+    mpiexec -np 8 ../../naluX -i edgeContact3D.i -o edgeContact3D.log
     determine_pass_fail $testTol "edgeContact3D.log" "edgeContact3D.norm" "edgeContact3D.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/edgeHybridFluids/edgeHybridFluids.sh
+++ b/nightly/edgeHybridFluids/edgeHybridFluids.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i edgeHybridFluids.i -o edgeHybridFluids.log
+    mpiexec -np 8 ../../naluX -i edgeHybridFluids.i -o edgeHybridFluids.log
     determine_pass_fail $testTol "edgeHybridFluids.log" "edgeHybridFluids.norm" "edgeHybridFluids.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/edgePipeCHT/edgePipeCHT.sh
+++ b/nightly/edgePipeCHT/edgePipeCHT.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i edgePipeCHT.i -o edgePipeCHT.log
+    mpiexec -np 4 ../../naluX -i edgePipeCHT.i -o edgePipeCHT.log
     determine_pass_fail $testTol "edgePipeCHT.log" "edgePipeCHT.norm" "edgePipeCHT.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/elemBackStepLRSST/elemBackStepLRSST.sh
+++ b/nightly/elemBackStepLRSST/elemBackStepLRSST.sh
@@ -23,7 +23,7 @@ if [ -f $CWD/PASS ]; then
     didSimulationDiffAnywhere=0
 else
     # run the first case
-    mpiexec --np 4 ../../naluX -i elemBackStepLRSST.i -o elemBackStepLRSST.log
+    mpiexec -np 4 ../../naluX -i elemBackStepLRSST.i -o elemBackStepLRSST.log
     determine_pass_fail $testTol "elemBackStepLRSST.log" "elemBackStepLRSST.norm" "elemBackStepLRSST.norm.gold"
     didSimulationDiffAnywhereFirst="$?"
     localDiffOne=$GlobalMaxSolutionDiff
@@ -32,7 +32,7 @@ else
     fi
 
     # run the second case
-    mpiexec --np 4 ../../naluX -i elemBackStepLRSST_Input.i -o elemBackStepLRSST_Input.log
+    mpiexec -np 4 ../../naluX -i elemBackStepLRSST_Input.i -o elemBackStepLRSST_Input.log
     determine_pass_fail $testTol "elemBackStepLRSST_Input.log" "elemBackStepLRSST_Input.norm" "elemBackStepLRSST_Input.norm.gold"
     didSimulationDiffAnywhereSecond="$?"
     localDiffTwo=$GlobalMaxSolutionDiff

--- a/nightly/elemClosedDomain/elemClosedDomain.sh
+++ b/nightly/elemClosedDomain/elemClosedDomain.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 2 ../../naluX -i elemClosedDomain.i -o elemClosedDomain.log
+    mpiexec -np 2 ../../naluX -i elemClosedDomain.i -o elemClosedDomain.log
     determine_pass_fail $testTol "elemClosedDomain.log" "elemClosedDomain.norm" "elemClosedDomain.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/elemHybridFluids/elemHybridFluids.sh
+++ b/nightly/elemHybridFluids/elemHybridFluids.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i elemHybridFluids.i -o elemHybridFluids.log
+    mpiexec -np 8 ../../naluX -i elemHybridFluids.i -o elemHybridFluids.log
     determine_pass_fail $testTol "elemHybridFluids.log" "elemHybridFluids.norm" "elemHybridFluids.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/elemHybridFluidsShift/elemHybridFluidsShift.sh
+++ b/nightly/elemHybridFluidsShift/elemHybridFluidsShift.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i elemHybridFluidsShift.i -o elemHybridFluidsShift.log
+    mpiexec -np 8 ../../naluX -i elemHybridFluidsShift.i -o elemHybridFluidsShift.log
     determine_pass_fail $testTol "elemHybridFluidsShift.log" "elemHybridFluidsShift.norm" "elemHybridFluidsShift.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/elemPipeCHT/elemPipeCHT.sh
+++ b/nightly/elemPipeCHT/elemPipeCHT.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i elemPipeCHT.i -o elemPipeCHT.log
+    mpiexec -np 4 ../../naluX -i elemPipeCHT.i -o elemPipeCHT.log
     determine_pass_fail $testTol "elemPipeCHT.log" "elemPipeCHT.norm" "elemPipeCHT.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/femHC/femHC.sh
+++ b/nightly/femHC/femHC.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP1 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 2 ../../naluX -i femHC.i -o femHC.log
+    mpiexec -np 2 ../../naluX -i femHC.i -o femHC.log
     determine_pass_fail $testTol "femHC.log" "femHC.norm" "femHC.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic.sh
+++ b/nightly/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i fluidsPmrChtPeriodic.i -o fluidsPmrChtPeriodic.log
+    mpiexec -np 8 ../../naluX -i fluidsPmrChtPeriodic.i -o fluidsPmrChtPeriodic.log
     determine_pass_fail $testTol "fluidsPmrChtPeriodic.log" "fluidsPmrChtPeriodic.norm" "fluidsPmrChtPeriodic.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/hdf5VarZChi/hdf5VarZChi.sh
+++ b/nightly/hdf5VarZChi/hdf5VarZChi.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i hdf5VarZChi.i -o hdf5VarZChi.log
+    mpiexec -np 4 ../../naluX -i hdf5VarZChi.i -o hdf5VarZChi.log
     determine_pass_fail $testTol "hdf5VarZChi.log" "hdf5VarZChi.norm" "hdf5VarZChi.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/heatedBackStep/heatedBackStep.sh
+++ b/nightly/heatedBackStep/heatedBackStep.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i heatedBackStep.i -o heatedBackStep.log
+    mpiexec -np 4 ../../naluX -i heatedBackStep.i -o heatedBackStep.log
     determine_pass_fail $testTol "heatedBackStep.log" "heatedBackStep.norm" "heatedBackStep.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/heatedWaterChannel/heatedWaterChannel.sh
+++ b/nightly/heatedWaterChannel/heatedWaterChannel.sh
@@ -31,7 +31,7 @@ if [ -f $CWD/PASS ]; then
     didSimulationDiffAnywhere=0
 else
     # run the first
-    mpiexec --np 4 ../../naluX -i heatedWaterChannelEdge.i -o heatedWaterChannelEdge.log
+    mpiexec -np 4 ../../naluX -i heatedWaterChannelEdge.i -o heatedWaterChannelEdge.log
     determine_pass_fail $testTol "heatedWaterChannelEdge.log" "heatedWaterChannelEdge.norm" "$theGoldNormEdge"
     didSimulationDiffAnywhereFirst="$?"
     localDiffOne=$GlobalMaxSolutionDiff
@@ -40,7 +40,7 @@ else
     fi
 
     # run the second
-    mpiexec --np 4 ../../naluX -i heatedWaterChannelElem.i -o heatedWaterChannelElem.log
+    mpiexec -np 4 ../../naluX -i heatedWaterChannelElem.i -o heatedWaterChannelElem.log
     determine_pass_fail $testTol "heatedWaterChannelElem.log" "heatedWaterChannelElem.norm" "$theGoldNormElem"
     didSimulationDiffAnywhereSecond="$?"
     localDiffTwo=$GlobalMaxSolutionDiff
@@ -49,7 +49,7 @@ else
     fi
 
     # run the third
-    mpiexec --np 4 ../../naluX -i heatedWaterChannelEdgeRst.i -o heatedWaterChannelEdgeRst.log
+    mpiexec -np 4 ../../naluX -i heatedWaterChannelEdgeRst.i -o heatedWaterChannelEdgeRst.log
     determine_pass_fail $testTol "heatedWaterChannelEdgeRst.log" "heatedWaterChannelEdgeRst.norm" "$theGoldNormEdgeRst"
     didSimulationDiffAnywhereThird="$?"
     localDiffThree=$GlobalMaxSolutionDiff

--- a/nightly/heliumPlume/heliumPlume.sh
+++ b/nightly/heliumPlume/heliumPlume.sh
@@ -23,7 +23,7 @@ if [ -f $CWD/PASS ]; then
     didSimulationDiffAnywhere=0
 else
     # run the first case
-    mpiexec --np 8 ../../naluX -i heliumPlumeEdge.i -o heliumPlumeEdge.log
+    mpiexec -np 8 ../../naluX -i heliumPlumeEdge.i -o heliumPlumeEdge.log
     determine_pass_fail $testTol "heliumPlumeEdge.log" "heliumPlumeEdge.norm" "heliumPlumeEdge.norm.gold"
     didSimulationDiffAnywhereFirst="$?"
     localDiffOne=$GlobalMaxSolutionDiff
@@ -32,7 +32,7 @@ else
     fi
 
     # run the second case
-    mpiexec --np 8 ../../naluX -i heliumPlumeElem_rst.i -o heliumPlumeElem_rst.log
+    mpiexec -np 8 ../../naluX -i heliumPlumeElem_rst.i -o heliumPlumeElem_rst.log
     determine_pass_fail $testTol "heliumPlumeElem_rst.log" "heliumPlumeElem_rst.norm" "heliumPlumeElem_rst.norm.gold"
     didSimulationDiffAnywhereSecond="$?"
     localDiffTwo=$GlobalMaxSolutionDiff

--- a/nightly/hoHelium/hoHelium.sh
+++ b/nightly/hoHelium/hoHelium.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i hoHelium.i -o hoHelium.log
+    mpiexec -np 8 ../../naluX -i hoHelium.i -o hoHelium.log
     determine_pass_fail $testTol "hoHelium.log" "hoHelium.norm" "hoHelium.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/hoVortex/hoVortex.sh
+++ b/nightly/hoVortex/hoVortex.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 2 ../../naluX -i hoVortex.i -o hoVortex.log
+    mpiexec -np 2 ../../naluX -i hoVortex.i -o hoVortex.log
     determine_pass_fail $testTol "hoVortex.log" "hoVortex.norm" "hoVortex.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/inputFireEdgeUpwind/inputFireEdgeUpwind.sh
+++ b/nightly/inputFireEdgeUpwind/inputFireEdgeUpwind.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i inputFireEdgeUpwind.i -o inputFireEdgeUpwind.log
+    mpiexec -np 4 ../../naluX -i inputFireEdgeUpwind.i -o inputFireEdgeUpwind.log
     determine_pass_fail $testTol "inputFireEdgeUpwind.log" "inputFireEdgeUpwind.norm" "inputFireEdgeUpwind.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/inputFireElem/inputFireElem.sh
+++ b/nightly/inputFireElem/inputFireElem.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i inputFireElem.i -o inputFireElem.log
+    mpiexec -np 4 ../../naluX -i inputFireElem.i -o inputFireElem.log
     determine_pass_fail $testTol "inputFireElem.log" "inputFireElem.norm" "inputFireElem.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/milestoneRun/milestoneRun.sh
+++ b/nightly/milestoneRun/milestoneRun.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i milestoneRun.i -o milestoneRun.log
+    mpiexec -np 4 ../../naluX -i milestoneRun.i -o milestoneRun.log
     determine_pass_fail $testTol "milestoneRun.log" "milestoneRun.norm" "milestoneRun.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/mixedTetPipe/mixedTetPipe.sh
+++ b/nightly/mixedTetPipe/mixedTetPipe.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i mixedTetPipe.i -o mixedTetPipe.log
+    mpiexec -np 8 ../../naluX -i mixedTetPipe.i -o mixedTetPipe.log
     determine_pass_fail $testTol "mixedTetPipe.log" "mixedTetPipe.norm" "mixedTetPipe.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/movingCylinder/movingCylinder.sh
+++ b/nightly/movingCylinder/movingCylinder.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i movingCylinder.i -o movingCylinder.log
+    mpiexec -np 4 ../../naluX -i movingCylinder.i -o movingCylinder.log
     determine_pass_fail $testTol "movingCylinder.log" "movingCylinder.norm" "movingCylinder.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/nonIsoEdgeOpenJet/nonIsoEdgeOpenJet.sh
+++ b/nightly/nonIsoEdgeOpenJet/nonIsoEdgeOpenJet.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i nonIsoEdgeOpenJet.i -o nonIsoEdgeOpenJet.log
+    mpiexec -np 4 ../../naluX -i nonIsoEdgeOpenJet.i -o nonIsoEdgeOpenJet.log
     determine_pass_fail $testTol "nonIsoEdgeOpenJet.log" "nonIsoEdgeOpenJet.norm" "nonIsoEdgeOpenJet.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/nonIsoElemOpenJet/nonIsoElemOpenJet.sh
+++ b/nightly/nonIsoElemOpenJet/nonIsoElemOpenJet.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i nonIsoElemOpenJet.i -o nonIsoElemOpenJet.log
+    mpiexec -np 4 ../../naluX -i nonIsoElemOpenJet.i -o nonIsoElemOpenJet.log
     determine_pass_fail $testTol "nonIsoElemOpenJet.log" "nonIsoElemOpenJet.norm" "nonIsoElemOpenJet.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/nonIsoNonUniformEdgeOpenJet/nonIsoNonUniformEdgeOpenJet.sh
+++ b/nightly/nonIsoNonUniformEdgeOpenJet/nonIsoNonUniformEdgeOpenJet.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i nonIsoNonUniformEdgeOpenJet.i -o nonIsoNonUniformEdgeOpenJet.log
+    mpiexec -np 4 ../../naluX -i nonIsoNonUniformEdgeOpenJet.i -o nonIsoNonUniformEdgeOpenJet.log
     determine_pass_fail $testTol "nonIsoNonUniformEdgeOpenJet.log" "nonIsoNonUniformEdgeOpenJet.norm" "nonIsoNonUniformEdgeOpenJet.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/nonIsoNonUniformElemOpenJet/nonIsoNonUniformElemOpenJet.sh
+++ b/nightly/nonIsoNonUniformElemOpenJet/nonIsoNonUniformElemOpenJet.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i nonIsoNonUniformElemOpenJet.i -o nonIsoNonUniformElemOpenJet.log
+    mpiexec -np 4 ../../naluX -i nonIsoNonUniformElemOpenJet.i -o nonIsoNonUniformElemOpenJet.log
     determine_pass_fail $testTol "nonIsoNonUniformElemOpenJet.log" "nonIsoNonUniformElemOpenJet.norm" "nonIsoNonUniformElemOpenJet.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/overset/overset.sh
+++ b/nightly/overset/overset.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 6 ../../naluX -i overset.i -o overset.log
+    mpiexec -np 6 ../../naluX -i overset.i -o overset.log
     determine_pass_fail $testTol "overset.log" "overset.norm" "overset.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/oversetFluids/oversetFluids.sh
+++ b/nightly/oversetFluids/oversetFluids.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 6 ../../naluX -i oversetFluids.i -o oversetFluids.log
+    mpiexec -np 6 ../../naluX -i oversetFluids.i -o oversetFluids.log
     determine_pass_fail $testTol "oversetFluids.log" "oversetFluids.norm" "oversetFluids.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/oversetFluidsEdge/oversetFluidsEdge.sh
+++ b/nightly/oversetFluidsEdge/oversetFluidsEdge.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 6 ../../naluX -i oversetFluidsEdge.i -o oversetFluidsEdge.log
+    mpiexec -np 6 ../../naluX -i oversetFluidsEdge.i -o oversetFluidsEdge.log
     determine_pass_fail $testTol "oversetFluidsEdge.log" "oversetFluidsEdge.norm" "oversetFluidsEdge.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/periodic3dEdge/periodic3dEdgeNp1.sh
+++ b/nightly/periodic3dEdge/periodic3dEdgeNp1.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP1 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 1 ../../naluX -i periodic3dEdge.i -o periodic3dEdgeNp1.log
+    mpiexec -np 1 ../../naluX -i periodic3dEdge.i -o periodic3dEdgeNp1.log
     determine_pass_fail $testTol "periodic3dEdgeNp1.log" "periodic3dEdgeNp1.norm" "periodic3dEdgeNp1.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/periodic3dEdge/periodic3dEdgeNp4.sh
+++ b/nightly/periodic3dEdge/periodic3dEdgeNp4.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP4 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i periodic3dEdge.i -o periodic3dEdgeNp4.log
+    mpiexec -np 4 ../../naluX -i periodic3dEdge.i -o periodic3dEdgeNp4.log
     determine_pass_fail $testTol "periodic3dEdgeNp4.log" "periodic3dEdgeNp4.norm" "periodic3dEdgeNp4.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/periodic3dEdge/periodic3dEdgeNp8.sh
+++ b/nightly/periodic3dEdge/periodic3dEdgeNp8.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP8 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i periodic3dEdge.i -o periodic3dEdgeNp8.log
+    mpiexec -np 8 ../../naluX -i periodic3dEdge.i -o periodic3dEdgeNp8.log
     determine_pass_fail $testTol "periodic3dEdgeNp8.log" "periodic3dEdgeNp8.norm" "periodic3dEdgeNp8.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/periodic3dElem/periodic3dElemNp1.sh
+++ b/nightly/periodic3dElem/periodic3dElemNp1.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP1 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 1 ../../naluX -i periodic3dElem.i -o periodic3dElemNp1.log
+    mpiexec -np 1 ../../naluX -i periodic3dElem.i -o periodic3dElemNp1.log
     determine_pass_fail $testTol "periodic3dElemNp1.log" "periodic3dElemNp1.norm" "periodic3dElemNp1.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/periodic3dElem/periodic3dElemNp4.sh
+++ b/nightly/periodic3dElem/periodic3dElemNp4.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP4 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i periodic3dElem.i -o periodic3dElemNp4.log
+    mpiexec -np 4 ../../naluX -i periodic3dElem.i -o periodic3dElemNp4.log
     determine_pass_fail $testTol "periodic3dElemNp4.log" "periodic3dElemNp4.norm" "periodic3dElemNp4.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/periodic3dElem/periodic3dElemNp8.sh
+++ b/nightly/periodic3dElem/periodic3dElemNp8.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS_NP8 ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i periodic3dElem.i -o periodic3dElemNp8.log
+    mpiexec -np 8 ../../naluX -i periodic3dElem.i -o periodic3dElemNp8.log
     determine_pass_fail $testTol "periodic3dElemNp8.log" "periodic3dElemNp8.norm" "periodic3dElemNp8.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/quad9HC/quad9HC.sh
+++ b/nightly/quad9HC/quad9HC.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 2 ../../naluX -i quad9HC.i -o quad9HC.log
+    mpiexec -np 2 ../../naluX -i quad9HC.i -o quad9HC.log
     determine_pass_fail $testTol "quad9HC.log" "quad9HC.norm" "quad9HC.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/steadyTaylorVortex/steadyTaylorVortex.sh
+++ b/nightly/steadyTaylorVortex/steadyTaylorVortex.sh
@@ -18,7 +18,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 4 ../../naluX -i steadyTaylorVortex.i -o steadyTaylorVortex.log
+    mpiexec -np 4 ../../naluX -i steadyTaylorVortex.i -o steadyTaylorVortex.log
     determine_pass_fail $testTol "steadyTaylorVortex.log" "steadyTaylorVortex.norm" "steadyTaylorVortex.norm.gold"
     didSimulationDiffAnywhere="$?"
 fi

--- a/nightly/variableDensMMS/variableDensMMS.sh
+++ b/nightly/variableDensMMS/variableDensMMS.sh
@@ -23,7 +23,7 @@ if [ -f $CWD/PASS ]; then
     didSimulationDiffAnywhere=0
 else
     # run the first case
-    mpiexec --np 2 ../../naluX -i variableDensNonUniform.i -o variableDensNonUniform.log
+    mpiexec -np 2 ../../naluX -i variableDensNonUniform.i -o variableDensNonUniform.log
     determine_pass_fail $testTol "variableDensNonUniform.log" "variableDensNonUniform.norm" "variableDensNonUniform.norm.gold"
     didSimulationDiffAnywhereFirst="$?"
     localDiffOne=$GlobalMaxSolutionDiff
@@ -32,7 +32,7 @@ else
     fi
 
     # run the second case
-    mpiexec --np 2 ../../naluX -i variableDensNonIso.i -o variableDensNonIso.log
+    mpiexec -np 2 ../../naluX -i variableDensNonIso.i -o variableDensNonIso.log
     determine_pass_fail $testTol "variableDensNonIso.log" "variableDensNonIso.norm" "variableDensNonIso.norm.gold"
     didSimulationDiffAnywhereSecond="$?"
     localDiffTwo=$GlobalMaxSolutionDiff

--- a/performance/oversetHybrid/oversetHybrid.sh
+++ b/performance/oversetHybrid/oversetHybrid.sh
@@ -20,7 +20,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i oversetHybrid.i -o oversetHybrid.log
+    mpiexec -np 8 ../../naluX -i oversetHybrid.i -o oversetHybrid.log
     determine_pass_fail $testTol "oversetHybrid.log" "oversetHybrid.norm" "$theGoldNorm"
     didSimulationDiffAnywhere="$?"
 fi

--- a/performance/uqSlidingMesh/uqSlidingMesh.sh
+++ b/performance/uqSlidingMesh/uqSlidingMesh.sh
@@ -20,7 +20,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i uqSlidingMesh.i -o uqSlidingMesh.log
+    mpiexec -np 8 ../../naluX -i uqSlidingMesh.i -o uqSlidingMesh.log
     determine_pass_fail $testTol "uqSlidingMesh.log" "uqSlidingMesh.norm" "$theGoldNorm"
     didSimulationDiffAnywhere="$?"
 fi

--- a/performance/waleElemXflowMixFrac3.5m/waleElemXflowMixFrac3.5m.sh
+++ b/performance/waleElemXflowMixFrac3.5m/waleElemXflowMixFrac3.5m.sh
@@ -20,7 +20,7 @@ if [ -f $CWD/PASS ]; then
     # already ran this test
     didSimulationDiffAnywhere=0
 else
-    mpiexec --np 8 ../../naluX -i waleElemXflowMixFrac3.5m.i -o waleElemXflowMixFrac3.5m.log
+    mpiexec -np 8 ../../naluX -i waleElemXflowMixFrac3.5m.i -o waleElemXflowMixFrac3.5m.log
     determine_pass_fail $testTol "waleElemXflowMixFrac3.5m.log" "waleElemXflowMixFrac3.5m.norm" "$theGoldNorm"
     didSimulationDiffAnywhere="$?"
 fi


### PR DESCRIPTION
Intel mpiexec throws a unrecognized option error when using the '--np'
option so this was changed in all the test scripts to '-np' using the
following command (in zsh shell) `sed -i -- 's/--np/-np/g' **/*.sh(D.)`